### PR TITLE
MT-2358: Update service ownership to marketplace-institute-of-technology

### DIFF
--- a/service-level.yaml
+++ b/service-level.yaml
@@ -1,6 +1,6 @@
 services:
   - name: godaddy-php-sdk
-    owner: quackoverflow
+    owner: marketplace-institute-of-technology
     language: php
     nonServiceType: library
     description: PHP SDK for the GoDaddy microservice distributed to Packagist


### PR DESCRIPTION
## What
Updates the `owner` field in `service-level.yaml` from `quackoverflow` to `marketplace-institute-of-technology`.

## Why
The `quackoverflow` team no longer exists; its responsibilities have been absorbed by the `marketplace-institute-of-technology` team (MT-2358).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Jira: [MT-2358](https://vendasta.jira.com/browse/MT-2358)
cc @vendasta/marketplace-institute-of-technology

[MT-2358]: https://vendasta.jira.com/browse/MT-2358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ